### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ simpleeval
 ultralytics
 ultralyticsplus
 CLIPSeg
-OpenCV
+opencv-python


### PR DESCRIPTION
OpenCV doesn't exist on pypi:

```bash
ERROR: Could not find a version that satisfies the requirement opencv (from versions: none)
ERROR: No matching distribution found for opencv
```

But there is opencv-python: https://pypi.org/project/opencv-python/

```bash
pip install opencv-python
python -c "import cv2;print('success')"
>>> success
```